### PR TITLE
Add altitude property

### DIFF
--- a/adafruit_dps310.py
+++ b/adafruit_dps310.py
@@ -45,6 +45,7 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DPS310.git"
 
 # Common imports; remove if unused or pylint will complain
+import math
 from time import sleep
 import adafruit_bus_device.i2c_device as i2c_device
 from adafruit_register.i2c_struct import UnaryStruct, ROUnaryStruct
@@ -234,6 +235,8 @@ class DPS310:
             1040384,
             2088960,
         )
+        self.sea_level_pressure = 1013.25
+        """Pressure in hectoPascals at sea level. Used to calibrate `altitude`."""
         self.initialize()
 
     def initialize(self):
@@ -300,6 +303,13 @@ class DPS310:
 
         final_pressure = pres_calc / 100
         return final_pressure
+
+    @property
+    def altitude(self):
+        """The altitude based on the sea level pressure (`sea_level_pressure`) - which you must
+           enter ahead of time)"""
+        p = self.pressure  # in Si units for hPascal
+        return 44330 * (1.0 - math.pow(p / self.sea_level_pressure, 0.1903))
 
     @property
     def temperature(self):

--- a/adafruit_dps310.py
+++ b/adafruit_dps310.py
@@ -308,8 +308,7 @@ class DPS310:
     def altitude(self):
         """The altitude based on the sea level pressure (`sea_level_pressure`) - which you must
            enter ahead of time)"""
-        p = self.pressure  # in Si units for hPascal
-        return 44330 * (1.0 - math.pow(p / self.sea_level_pressure, 0.1903))
+        return 44330 * (1.0 - math.pow(self.pressure / self.sea_level_pressure, 0.1903))
 
     @property
     def temperature(self):


### PR DESCRIPTION
For #8. Adds an `altitude` property.

```python
Adafruit CircuitPython 5.3.1 on 2020-07-13; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board
>>> import adafruit_dps310
>>> dps310 = adafruit_dps310.DPS310(board.I2C())
>>> dps310.altitude
65.4015
>>> dps310.sea_level_pressure
1013.25
>>> dps310.sea_level_pressure = 1012.42
>>> dps310.altitude
58.4471
>>> 
```