### PR TITLE
Adding readme note regarding M0 boards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Caveat: by default the library initializes the IC with constant temperature and 
 Known Issues
 ============
 Library extensive features might not be compatible with memory limited boards. Library might not
-load in M0 boards.
+load in SAMD21 boards and others with 32KB or RAM or less.
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Caveat: by default the library initializes the IC with constant temperature and 
 Known Issues
 ============
 Library extensive features might not be compatible with memory limited boards. Library might not
-load in SAMD21 boards and others with 32KB or RAM or less.
+load in SAMD21 boards and others with 32KB of RAM or less.
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,13 @@ Caveat: by default the library initializes the IC with constant temperature and 
     dps310.wait_pressure_ready()
 
 
+
+Known Issues
+============
+Library extensive features might not be compatible with memory limited boards. Library might not
+load in M0 boards.
+
+
 Contributing
 ============
 

--- a/adafruit_dps310.py
+++ b/adafruit_dps310.py
@@ -15,14 +15,21 @@ Implementation Notes
 
 **Hardware:**
 
-* Adafruit's DPS310 Breakout: https://www.adafruit.com/product/4494
+* `Adafruit DPS310 Precision Barometric Pressure / Altitude Sensor
+  https://www.adafruit.com/product/4494`_ (Product ID: 4494)
 
 **Software and Dependencies:**
 
 * Adafruit CircuitPython firmware for the supported boards:
   https://circuitpython.org/downloads
-* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
-* Adafruit's Register library: https://github.com/adafruit/Adafruit_CircuitPython_Register"""
+
+* Adafruit's Bus Device library:
+  https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+
+* Adafruit's Register library:
+  https://github.com/adafruit/Adafruit_CircuitPython_Register
+
+"""
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_DPS310.git"

--- a/adafruit_dps310.py
+++ b/adafruit_dps310.py
@@ -16,7 +16,7 @@ Implementation Notes
 **Hardware:**
 
 * `Adafruit DPS310 Precision Barometric Pressure / Altitude Sensor
-  https://www.adafruit.com/product/4494`_ (Product ID: 4494)
+  <https://www.adafruit.com/product/4494>`_ (Product ID: 4494)
 
 **Software and Dependencies:**
 


### PR DESCRIPTION
Intents to solve #10 .

I tried to load the library in 
```python
Adafruit CircuitPython 6.1.0 on 2021-01-21; Adafruit QT Py M0 with samd21e18
```
No success

Also try to see where in the library was the cut-in to avoid the memory allocation problem, but after some tries the board just said no disk space left, so one of the reasons of taking this path instead of the refactor.
Feel free to reject if at the end the note in the readme is not what we want.