### PR TITLE
Default import

### DIFF
--- a/adafruit_dps310/__init__.py
+++ b/adafruit_dps310/__init__.py
@@ -1,1 +1,16 @@
+# SPDX-FileCopyrightText: 2022 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_dps310`
+================================================================================
+Dynamic progress bar widget for CircuitPython displays
+* Author(s): Bryan Siepert, Jose David M.
+Implementation Notes
+--------------------
+**Software and Dependencies:**
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+"""
 from adafruit_dps310.advanced import DPS310_Advanced as DPS310

--- a/adafruit_dps310/__init__.py
+++ b/adafruit_dps310/__init__.py
@@ -1,0 +1,1 @@
+from adafruit_dps310.advanced import DPS310_Advanced as DPS310

--- a/adafruit_dps310/__init__.py
+++ b/adafruit_dps310/__init__.py
@@ -1,17 +1,13 @@
-# SPDX-FileCopyrightText: 2022 Tim Cocks for Adafruit Industries
+# SPDX-FileCopyrightText: 2020 Bryan Siepert for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
 """
 `adafruit_dps310`
 ================================================================================
+
 Library for the DPS310 Precision Barometric Pressure Sensor
 
 * Author(s): Bryan Siepert, Jose David M.
-Implementation Notes
---------------------
-**Software and Dependencies:**
-* Adafruit CircuitPython firmware for the supported boards:
-  https://github.com/adafruit/circuitpython/releases
 """
 from adafruit_dps310.advanced import DPS310_Advanced as DPS310

--- a/adafruit_dps310/__init__.py
+++ b/adafruit_dps310/__init__.py
@@ -5,7 +5,8 @@
 """
 `adafruit_dps310`
 ================================================================================
-Dynamic progress bar widget for CircuitPython displays
+Library for the DPS310 Precision Barometric Pressure Sensor
+
 * Author(s): Bryan Siepert, Jose David M.
 Implementation Notes
 --------------------


### PR DESCRIPTION
This change allows the previous version of import for this library to work correctly. Defaulting to the advanced version of the driver.