### PR TITLE
Fix address passing for DPS310_Advanced

### DIFF
--- a/adafruit_dps310/advanced.py
+++ b/adafruit_dps310/advanced.py
@@ -197,7 +197,7 @@ class DPS310_Advanced(DPS310):
     _temp_ratebits = RWBits(3, _DPS310_TMPCFG, 4)
 
     def __init__(self, i2c_bus, address=_DPS310_DEFAULT_ADDRESS):
-        super().__init__(i2c_bus, _DPS310_DEFAULT_ADDRESS)
+        super().__init__(i2c_bus, address)
 
     def initialize(self):
         """Initialize the sensor to continuous measurement"""

--- a/adafruit_dps310/advanced.py
+++ b/adafruit_dps310/advanced.py
@@ -196,9 +196,6 @@ class DPS310_Advanced(DPS310):
     _pressure_ratebits = RWBits(3, _DPS310_PRSCFG, 4)
     _temp_ratebits = RWBits(3, _DPS310_TMPCFG, 4)
 
-    def __init__(self, i2c_bus, address=_DPS310_DEFAULT_ADDRESS):
-        super().__init__(i2c_bus, address)
-
     def initialize(self):
         """Initialize the sensor to continuous measurement"""
 


### PR DESCRIPTION
For #21. Untested, but appears to be a very simple bug.

Another option could be to remove `__init__` from `DPS310_Advanced` since all it is doing is calling `super().__init__` with no changes.
**EDIT** - well, that's what pylint wants anyway...so going with that.